### PR TITLE
Fix search of strings with a capital letter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ const getTextNodesInElementContainingText = (element, text) => {
   const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
   let node;
   while ((node = walker.nextNode())) {
-    if (node.textContent?.toLowerCase().includes(text)) {
+    if (node.textContent?.toLowerCase().includes(text.toLowerCase())) {
       nodes.push(node);
     }
   }
@@ -59,7 +59,7 @@ const getRangesForSearchTermInElement = (element, search) => {
   const text = element.textContent?.toLowerCase() || "";
   let start = 0;
   let index;
-  while ((index = text.indexOf(search, start)) >= 0) {
+  while ((index = text.indexOf(search.toLowerCase(), start)) >= 0) {
     const range = new Range();
     range.setStart(element.firstChild, index);
     range.setEnd(element.firstChild, index + search.length);


### PR DESCRIPTION
## Problem 

If your text is composed by words with capital cases like this one :
```
This is the content I Search
```
And you search that in your input
```
Search
```
Nothing happens

## Solution
Put the search in the toLowerCase function as already done for the content